### PR TITLE
Fix handling of the restart during unbonding

### DIFF
--- a/walletcontroller/client.go
+++ b/walletcontroller/client.go
@@ -304,6 +304,21 @@ func (w *RpcWalletController) SignBip322NativeSegwit(msg []byte, address btcutil
 	return signed.TxIn[0].Witness, nil
 }
 
+func (w *RpcWalletController) OutputSpent(
+	txHash *chainhash.Hash,
+	outputIdx uint32,
+) (bool, error) {
+	res, err := w.Client.GetTxOut(
+		txHash, outputIdx, true,
+	)
+
+	if err != nil {
+		return false, err
+	}
+
+	return res == nil, nil
+}
+
 // TODO: Temporary implementation to encapsulate signing of taproot spending transaction, it will be replaced with PSBT
 // signing in the future
 func (w *RpcWalletController) SignOneInputTaprootSpendingTransaction(req *TaprootSigningRequest) (*TaprootSigningResult, error) {

--- a/walletcontroller/interface.go
+++ b/walletcontroller/interface.go
@@ -57,4 +57,8 @@ type WalletController interface {
 	// SignOneInputTaprootSpendingTransaction signs transactions with one taproot input that
 	// uses script spending path.
 	SignOneInputTaprootSpendingTransaction(req *TaprootSigningRequest) (*TaprootSigningResult, error)
+	OutputSpent(
+		txHash *chainhash.Hash,
+		outputIdx uint32,
+	) (bool, error)
 }


### PR DESCRIPTION
Fixes: https://github.com/babylonlabs-io/btc-staker/issues/18

Fixes handling of the case in which program crashes in between sending of unbonding transactions and unbonding transaction confirmation.


Note: this is still not perfect, as it may happen that:
- user requests unbonding
- call is returned to the user about success
- program crashes before unbonding tx is sent to btc
- to handle this properly new state would need to be introduces `UNBONDING_REQUESTED` but this would be breaking change to existing db that we want to avoid rn.

Follow up task: https://github.com/babylonlabs-io/btc-staker/issues/19


