### PR TITLE
Sign taproot thorugh psbt

### DIFF
--- a/itest/bitcoind_node_setup.go
+++ b/itest/bitcoind_node_setup.go
@@ -88,7 +88,7 @@ func (h *BitcoindTestHandler) CreateWallet(walletName string, passphrase string)
 	// last false on the list will create legacy wallet. This is needed, as currently
 	// we are signing all taproot transactions by dumping the private key and signing it
 	// on app level. Descriptor wallets do not allow dumping private keys.
-	buff, _, err := h.m.ExecBitcoindCliCmd(h.t, []string{"createwallet", walletName, "false", "false", passphrase, "false", "false"})
+	buff, _, err := h.m.ExecBitcoindCliCmd(h.t, []string{"createwallet", walletName, "false", "false", passphrase})
 	require.NoError(h.t, err)
 
 	var response CreateWalletResponse

--- a/itest/containers/config.go
+++ b/itest/containers/config.go
@@ -10,7 +10,7 @@ type ImageConfig struct {
 //nolint:deadcode
 const (
 	dockerBitcoindRepository = "lncm/bitcoind"
-	dockerBitcoindVersionTag = "v24.0.1"
+	dockerBitcoindVersionTag = "v26.0"
 )
 
 // NewImageConfig returns ImageConfig needed for running e2e test.

--- a/staker/babylontypes.go
+++ b/staker/babylontypes.go
@@ -91,6 +91,10 @@ func (app *StakerApp) buildOwnedDelegation(
 		return nil, fmt.Errorf("error signing slashing transaction for staking transaction: %w", err)
 	}
 
+	if stakingSlashingSig.Signature == nil {
+		return nil, fmt.Errorf("failed to receive stakingSlashingSig.Signature ")
+	}
+
 	unbondingSlashingSig, err := app.signTaprootScriptSpendUsingWallet(
 		undelegationDesc.SlashUnbondingTransaction,
 		undelegationDesc.UnbondingTransaction.TxOut[0],
@@ -103,13 +107,17 @@ func (app *StakerApp) buildOwnedDelegation(
 		return nil, fmt.Errorf("error signing slashing transaction for unbonding transaction: %w", err)
 	}
 
+	if unbondingSlashingSig.Signature == nil {
+		return nil, fmt.Errorf("failed to receive unbondingSlashingSig.Signature ")
+	}
+
 	dg := createDelegationData(
 		externalData.stakerPublicKey,
 		req.inclusionBlock,
 		req.txIndex,
 		storedTx,
 		stakingSlashingTx,
-		stakingSlashingSig,
+		stakingSlashingSig.Signature,
 		externalData.babylonStakerAddr,
 		stakingTxInclusionProof,
 		&cl.UndelegationData{
@@ -117,7 +125,7 @@ func (app *StakerApp) buildOwnedDelegation(
 			UnbondingTxValue:             undelegationDesc.UnbondingTxValue,
 			UnbondingTxUnbondingTime:     undelegationDesc.UnbondingTxUnbondingTime,
 			SlashUnbondingTransaction:    undelegationDesc.SlashUnbondingTransaction,
-			SlashUnbondingTransactionSig: unbondingSlashingSig,
+			SlashUnbondingTransactionSig: unbondingSlashingSig.Signature,
 		},
 	)
 

--- a/walletcontroller/client.go
+++ b/walletcontroller/client.go
@@ -1,6 +1,8 @@
 package walletcontroller
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -11,8 +13,10 @@ import (
 	scfg "github.com/babylonlabs-io/btc-staker/stakercfg"
 	"github.com/babylonlabs-io/btc-staker/types"
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
@@ -350,4 +354,110 @@ func (w *RpcWalletController) SignOneInputTaprootSpendingTransaction(req *Taproo
 	return &TaprootSigningResult{
 		Signature: sig,
 	}, nil
+}
+
+func (w *RpcWalletController) foo(request *TaprootSigningRequest) (*TaprootSigningResult, error) {
+	if len(request.TxToSign.TxIn) != 1 {
+		return nil, fmt.Errorf("cannot sign transaction with more than one input")
+	}
+
+	if !txscript.IsPayToTaproot(request.FundingOutput.PkScript) {
+		return nil, fmt.Errorf("cannot sign transaction spending non-taproot output")
+	}
+
+	key, err := w.AddressPublicKey(request.SignerAddress)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get public key for address: %w", err)
+	}
+
+	psbtPacket, err := psbt.New(
+		[]*wire.OutPoint{&request.TxToSign.TxIn[0].PreviousOutPoint},
+		request.TxToSign.TxOut,
+		request.TxToSign.Version,
+		request.TxToSign.LockTime,
+		[]uint32{request.TxToSign.TxIn[0].Sequence},
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create PSBT packet with transaction to sign: %w", err)
+	}
+
+	psbtPacket.Inputs[0].SighashType = txscript.SigHashDefault
+	psbtPacket.Inputs[0].WitnessUtxo = request.FundingOutput
+	psbtPacket.Inputs[0].Bip32Derivation = []*psbt.Bip32Derivation{
+		{
+			PubKey: key.SerializeCompressed(),
+		},
+	}
+
+	ctrlBlockBytes, err := request.SpendDescription.ControlBlock.ToBytes()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize control block: %w", err)
+	}
+
+	psbtPacket.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{
+		{
+			ControlBlock: ctrlBlockBytes,
+			Script:       request.SpendDescription.ScriptLeaf.Script,
+			LeafVersion:  request.SpendDescription.ScriptLeaf.LeafVersion,
+		},
+	}
+
+	psbtEncoded, err := psbtPacket.B64Encode()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode PSBT packet: %w", err)
+	}
+
+	sign := true
+	signResult, err := w.Client.WalletProcessPsbt(
+		psbtEncoded,
+		&sign,
+		"DEFAULT",
+		nil,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign PSBT packet: %w", err)
+	}
+
+	decodedBytes, err := base64.StdEncoding.DecodeString(signResult.Psbt)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode signed PSBT packet from b64: %w", err)
+	}
+
+	decodedPsbt, err := psbt.NewFromRawBytes(bytes.NewReader(decodedBytes), false)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode signed PSBT packet from bytes: %w", err)
+	}
+
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode signed PSBT packet: %w", err)
+	}
+
+	if len(decodedSignedPacket.Inputs[0].TaprootScriptSpendSig) == 0 {
+		// this can happen if btcwallet does not maintain the private key for the
+		// for the public in signing request
+		return nil, fmt.Errorf("no signature found in PSBT packet. Wallet does not maintain covenant public key")
+	}
+
+	schnorSignature := signedPacket.Inputs[0].TaprootScriptSpendSig[0].Signature
+
+	parsedSignature, err := schnorr.ParseSignature(schnorSignature)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse schnorr signature in psbt packet: %w", err)
+
+	}
+
+	result := &SigningResult{
+		Signature: parsedSignature,
+	}
+
+	return result, nil
 }

--- a/walletcontroller/interface.go
+++ b/walletcontroller/interface.go
@@ -30,12 +30,11 @@ type TaprootSigningRequest struct {
 	SpendDescription *SpendPathDescription
 }
 
+// TaprootSigningResult contains result of signing taproot spend through bitcoind
+// wallet. It will contain either Signature or FullInputWitness, never both.
 type TaprootSigningResult struct {
-	Signature *schnorr.Signature
-}
-
-type TaprootSigningResult struct {
-	Signature *schnorr.Signature
+	Signature        *schnorr.Signature
+	FullInputWitness wire.TxWitness
 }
 
 type WalletController interface {

--- a/walletcontroller/interface.go
+++ b/walletcontroller/interface.go
@@ -34,6 +34,10 @@ type TaprootSigningResult struct {
 	Signature *schnorr.Signature
 }
 
+type TaprootSigningResult struct {
+	Signature *schnorr.Signature
+}
+
 type WalletController interface {
 	UnlockWallet(timeoutSecs int64) error
 	AddressPublicKey(address btcutil.Address) (*btcec.PublicKey, error)


### PR DESCRIPTION
- Removes `DumpPrivateKey` from the staker codebase
- Uses `walletprocesspsbt` to sign taproot spends
- bump bitcoind to v26 in e2e test