### PR TITLE
chore: Use int64 for satoshi amount configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#53](https://github.com/babylonlabs-io/btc-staker/pull/53) Use only quorum of
 signatures when building unbonding transaction witness
 
+### Misc Improvements 
+
+* [51](https://github.com/babylonlabs-io/btc-staker/pull/51) Use int64
+  for satoshi amount related values.
+
 ## v0.7.0
 
 ### Api breaking

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3 as builder
+FROM golang:1.22.3 AS builder
 
 # Install cli tools for building and final image
 RUN apt-get update && apt-get install -y make git bash gcc curl jq

--- a/babylonclient/msgsender.go
+++ b/babylonclient/msgsender.go
@@ -21,12 +21,12 @@ var (
 type sendDelegationRequest struct {
 	utils.Request[*pv.RelayerTxResponse]
 	dg                          *DelegationData
-	requiredInclusionBlockDepth uint64
+	requiredInclusionBlockDepth uint32
 }
 
 func newSendDelegationRequest(
 	dg *DelegationData,
-	requiredInclusionBlockDepth uint64,
+	requiredInclusionBlockDepth uint32,
 ) sendDelegationRequest {
 	return sendDelegationRequest{
 		Request:                     utils.NewRequest[*pv.RelayerTxResponse](),
@@ -100,7 +100,7 @@ func (b *BabylonMsgSender) Stop() {
 
 // isBabylonBtcLcReady checks if Babylon BTC light client is ready to receive delegation
 func (b *BabylonMsgSender) isBabylonBtcLcReady(
-	requiredInclusionBlockDepth uint64,
+	requiredInclusionBlockDepth uint32,
 	req *DelegationData,
 ) error {
 	// no need to consult Babylon if we send delegation without inclusion proof
@@ -121,7 +121,7 @@ func (b *BabylonMsgSender) isBabylonBtcLcReady(
 		return fmt.Errorf("error while getting delegation data: %w", err)
 	}
 
-	if depth < requiredInclusionBlockDepth {
+	if uint32(depth) < requiredInclusionBlockDepth {
 		return fmt.Errorf("btc lc not ready, required depth: %d, current depth: %d: %w", requiredInclusionBlockDepth, depth, ErrBabylonBtcLightClientNotReady)
 	}
 
@@ -247,7 +247,7 @@ func (m *BabylonMsgSender) handleSentToBabylon() {
 
 func (m *BabylonMsgSender) SendDelegation(
 	dg *DelegationData,
-	requiredInclusionBlockDepth uint64,
+	requiredInclusionBlockDepth uint32,
 ) (*pv.RelayerTxResponse, error) {
 	req := newSendDelegationRequest(dg, requiredInclusionBlockDepth)
 

--- a/babylonclient/pop.go
+++ b/babylonclient/pop.go
@@ -13,7 +13,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-type BabylonBtcPopType int
+type BabylonBtcPopType uint32
 
 const (
 	SchnorrType BabylonBtcPopType = iota
@@ -39,7 +39,7 @@ func NewBabylonPop(t BabylonBtcPopType, btcSigOverBbnAddr []byte) (*BabylonPop, 
 	}, nil
 }
 
-// NewBabylonBip322Pop build proper BabylonPop in BIP322 style, it verifies the
+// NewBabylonBip322Pop build proper BabylonPop in BIP322 style, it verifies
 // the bip322 signature validity
 func NewBabylonBip322Pop(
 	msg []byte,

--- a/cmd/stakercli/admin/admin.go
+++ b/cmd/stakercli/admin/admin.go
@@ -62,7 +62,7 @@ func dumpCfg(c *cli.Context) error {
 	dir, _ := path.Split(configPath)
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(dir, os.ModeDir); err != nil {
 			return cli.NewExitError(
 				fmt.Sprintf("could not create config directory: %s", err.Error()),
 				1,

--- a/cmd/stakercli/daemon/daemoncommands.go
+++ b/cmd/stakercli/daemon/daemoncommands.go
@@ -36,7 +36,6 @@ const (
 	limitFlag                  = "limit"
 	fpPksFlag                  = "finality-providers-pks"
 	stakingTransactionHashFlag = "staking-transaction-hash"
-	feeRateFlag                = "fee-rate"
 	stakerAddressFlag          = "staker-address"
 )
 
@@ -167,10 +166,6 @@ var unbondCmd = cli.Command{
 			Name:     stakingTransactionHashFlag,
 			Usage:    "Hash of original staking transaction in bitcoin hex format",
 			Required: true,
-		},
-		cli.IntFlag{
-			Name:  feeRateFlag,
-			Usage: "fee rate to pay for unbonding tx in sats/kb",
 		},
 	},
 	Action: unbond,
@@ -372,18 +367,7 @@ func unbond(ctx *cli.Context) error {
 
 	stakingTransactionHash := ctx.String(stakingTransactionHashFlag)
 
-	feeRate := ctx.Int(feeRateFlag)
-
-	if feeRate < 0 {
-		return cli.NewExitError("Fee rate must be non-negative", 1)
-	}
-
-	var fr *int = nil
-	if feeRate > 0 {
-		fr = &feeRate
-	}
-
-	result, err := client.UnbondStaking(sctx, stakingTransactionHash, fr)
+	result, err := client.UnbondStaking(sctx, stakingTransactionHash)
 	if err != nil {
 		return err
 	}

--- a/cmd/stakercli/transaction/parsers.go
+++ b/cmd/stakercli/transaction/parsers.go
@@ -97,3 +97,14 @@ func parseTagFromHex(tagHex string) ([]byte, error) {
 
 	return tag, nil
 }
+
+func parseCovenantQuorumFromCliCtx(ctx *cli.Context) (uint32, error) {
+	covenantQuorumUint64 := ctx.Uint64(covenantQuorumFlag)
+	if covenantQuorumUint64 == 0 {
+		return 0, fmt.Errorf("covenant quorum should be greater than 0")
+	}
+	if covenantQuorumUint64 > math.MaxUint32 {
+		return 0, fmt.Errorf("covenant quorum should be less or equal to %d", math.MaxUint32)
+	}
+	return uint32(covenantQuorumUint64), nil
+}

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -1512,8 +1512,7 @@ func TestStakingUnbonding(t *testing.T) {
 
 	tm.waitForStakingTxState(t, txHash, proto.TransactionState_DELEGATION_ACTIVE)
 
-	feeRate := 2000
-	resp, err := tm.StakerClient.UnbondStaking(context.Background(), txHash.String(), &feeRate)
+	resp, err := tm.StakerClient.UnbondStaking(context.Background(), txHash.String())
 	require.NoError(t, err)
 
 	unbondingTxHash, err := chainhash.NewHashFromStr(resp.UnbondingTxHash)
@@ -1590,8 +1589,7 @@ func TestUnbondingRestartWaitingForSignatures(t *testing.T) {
 
 	tm.waitForStakingTxState(t, txHash, proto.TransactionState_DELEGATION_ACTIVE)
 
-	feeRate := 2000
-	unbondResponse, err := tm.StakerClient.UnbondStaking(context.Background(), txHash.String(), &feeRate)
+	unbondResponse, err := tm.StakerClient.UnbondStaking(context.Background(), txHash.String())
 	require.NoError(t, err)
 	unbondingTxHash, err := chainhash.NewHashFromStr(unbondResponse.UnbondingTxHash)
 	require.NoError(t, err)
@@ -1818,8 +1816,7 @@ func TestRecoverAfterRestartDuringWithdrawal(t *testing.T) {
 	tm.waitForStakingTxState(t, txHash, proto.TransactionState_DELEGATION_ACTIVE)
 
 	// Unbond staking transaction and wait for it to be included in mempool
-	feeRate := 2000
-	unbondResponse, err := tm.StakerClient.UnbondStaking(context.Background(), txHash.String(), &feeRate)
+	unbondResponse, err := tm.StakerClient.UnbondStaking(context.Background(), txHash.String())
 	require.NoError(t, err)
 	unbondingTxHash, err := chainhash.NewHashFromStr(unbondResponse.UnbondingTxHash)
 	require.NoError(t, err)

--- a/staker/babylontypes.go
+++ b/staker/babylontypes.go
@@ -28,10 +28,10 @@ type inclusionInfo struct {
 
 type sendDelegationRequest struct {
 	txHash chainhash.Hash
-	// optional field, if not provided, delegation will be send to Babylon without
+	// optional field, if not provided, delegation will be sent to Babylon without
 	// the inclusion proof
 	inclusionInfo               *inclusionInfo
-	requiredInclusionBlockDepth uint64
+	requiredInclusionBlockDepth uint32
 }
 
 func (app *StakerApp) buildOwnedDelegation(

--- a/stakercfg/config.go
+++ b/stakercfg/config.go
@@ -23,19 +23,13 @@ import (
 )
 
 const (
-	defaultDataDirname     = "data"
-	defaultTLSCertFilename = "tls.cert"
-	defaultTLSKeyFilename  = "tls.key"
-	defaultLogLevel        = "info"
-	defaultLogDirname      = "logs"
-	defaultLogFilename     = "stakerd.log"
-	DefaultRPCPort         = 15812
-	// DefaultAutogenValidity is the default validity of a self-signed
-	// certificate. The value corresponds to 14 months
-	// (14 months * 30 days * 24 hours).
-	defaultTLSCertDuration = 14 * 30 * 24 * time.Hour
-	defaultConfigFileName  = "stakerd.conf"
-	defaultFeeMode         = "static"
+	defaultDataDirname    = "data"
+	defaultLogLevel       = "info"
+	defaultLogDirname     = "logs"
+	defaultLogFilename    = "stakerd.log"
+	DefaultRPCPort        = 15812
+	defaultConfigFileName = "stakerd.conf"
+	defaultFeeMode        = "static"
 	// We are using 2 sat/vbyte as default min fee rate, as currently our size estimates
 	// for different transaction types are not very accurate and if we would use 1 sat/vbyte (minimum accepted by bitcoin network)
 	// we risk into having transactions rejected by the network due to low fee.
@@ -105,8 +99,8 @@ type BtcNodeBackendConfig struct {
 	Nodetype            string    `long:"nodetype" description:"type of node to connect to {bitcoind, btcd}"`
 	WalletType          string    `long:"wallettype" description:"type of wallet to connect to {bitcoind, btcwallet}"`
 	FeeMode             string    `long:"feemode" description:"fee mode to use for fee estimation {static, dynamic}. In dynamic mode fee will be estimated using backend node"`
-	MinFeeRate          uint64    `long:"minfeerate" description:"minimum fee rate to use for fee estimation in sat/vbyte. If fee estimation by connected btc node returns a lower fee rate, this value will be used instead"`
-	MaxFeeRate          uint64    `long:"maxfeerate" description:"maximum fee rate to use for fee estimation in sat/vbyte. If fee estimation by connected btc node returns a higher fee rate, this value will be used instead. It is also used as fallback if fee estimation by connected btc node fails and as fee rate in case of static estimator"`
+	MinFeeRate          int64     `long:"minfeerate" description:"minimum fee rate to use for fee estimation in sat/vbyte. If fee estimation by connected btc node returns a lower fee rate, this value will be used instead"`
+	MaxFeeRate          int64     `long:"maxfeerate" description:"maximum fee rate to use for fee estimation in sat/vbyte. If fee estimation by connected btc node returns a higher fee rate, this value will be used instead. It is also used as fallback if fee estimation by connected btc node fails and as fee rate in case of static estimator"`
 	Btcd                *Btcd     `group:"btcd" namespace:"btcd"`
 	Bitcoind            *Bitcoind `group:"bitcoind" namespace:"bitcoind"`
 	EstimationMode      types.FeeEstimationMode
@@ -305,7 +299,7 @@ func LoadConfig() (*Config, *logrus.Logger, *zap.Logger, error) {
 	// TODO: Add log rotation
 	// At this point we know config is valid, create logger which also log to file
 	logFilePath := filepath.Join(cleanCfg.LogDir, defaultLogFilename)
-	f, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	f, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -443,11 +437,11 @@ func ValidateConfig(cfg Config) (*Config, error) {
 		return nil, mkErr(fmt.Sprintf("invalid fee estimation mode: %s", cfg.BtcNodeBackendConfig.Nodetype))
 	}
 
-	if cfg.BtcNodeBackendConfig.MinFeeRate == 0 {
+	if cfg.BtcNodeBackendConfig.MinFeeRate <= 0 {
 		return nil, mkErr("minfeerate rate must be greater than 0")
 	}
 
-	if cfg.BtcNodeBackendConfig.MaxFeeRate == 0 {
+	if cfg.BtcNodeBackendConfig.MaxFeeRate <= 0 {
 		return nil, mkErr("maxfeerate rate must be greater than 0")
 	}
 

--- a/stakerservice/client/rpcclient.go
+++ b/stakerservice/client/rpcclient.go
@@ -195,15 +195,11 @@ func (c *StakerServiceJsonRpcClient) WatchStaking(
 	return result, nil
 }
 
-func (c *StakerServiceJsonRpcClient) UnbondStaking(ctx context.Context, txHash string, feeRate *int) (*service.UnbondingResponse, error) {
+func (c *StakerServiceJsonRpcClient) UnbondStaking(ctx context.Context, txHash string) (*service.UnbondingResponse, error) {
 	result := new(service.UnbondingResponse)
 
 	params := make(map[string]interface{})
 	params["stakingTxHash"] = txHash
-
-	if feeRate != nil {
-		params["feeRate"] = feeRate
-	}
 
 	_, err := c.client.Call(ctx, "unbond_staking", params, result)
 

--- a/stakerservice/service.go
+++ b/stakerservice/service.go
@@ -554,7 +554,7 @@ func (s *StakerService) GetRoutes() RoutesMap {
 		"staking_details":           rpc.NewRPCFunc(s.stakingDetails, "stakingTxHash"),
 		"spend_stake":               rpc.NewRPCFunc(s.spendStake, "stakingTxHash"),
 		"list_staking_transactions": rpc.NewRPCFunc(s.listStakingTransactions, "offset,limit"),
-		"unbond_staking":            rpc.NewRPCFunc(s.unbondStaking, "stakingTxHash,feeRate"),
+		"unbond_staking":            rpc.NewRPCFunc(s.unbondStaking, "stakingTxHash"),
 		"withdrawable_transactions": rpc.NewRPCFunc(s.withdrawableTransactions, "offset,limit"),
 		// watch api
 		"watch_staking_tx": rpc.NewRPCFunc(s.watchStaking, "stakingTx,stakingTime,stakingValue,stakerBtcPk,fpBtcPks,slashingTx,slashingTxSig,stakerBabylonAddr,stakerAddress,stakerBtcSig,unbondingTx,slashUnbondingTx,slashUnbondingTxSig,unbondingTime,popType"),


### PR DESCRIPTION
The libraries that we depend to use int64 for satoshi amount denominations. To be fully compatible with them,
it is better if we use similar types instead of doing conversions.

Further, this PR fixes some other type conversions and minor errors found by gosec.

Edit: tried to bump babylon dependency as well, but needs a version to be released first. 