### PR TITLE
Use only quorum number of covenant signature when building the witness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug fix
+
+- [#53](https://github.com/babylonlabs-io/btc-staker/pull/53) Use only quorum of
+signatures when building unbonding transaction witness
+
 ## v0.7.0
 
 ### Api breaking

--- a/babylonclient/babyloncontroller.go
+++ b/babylonclient/babyloncontroller.go
@@ -842,14 +842,13 @@ func (bc *BabylonController) IsTxAlreadyPartOfDelegation(stakingTxHash *chainhas
 
 // Test methods for e2e testing
 // Different babylon sig methods to support e2e testing
-func (bc *BabylonController) SubmitCovenantSig(
+func (bc *BabylonController) CreateCovenantMessage(
 	covPubKey *bbntypes.BIP340PubKey,
 	stakingTxHash string,
 	slashStakingAdaptorSigs [][]byte,
 	unbondindgSig *bbntypes.BIP340Signature,
 	slashUnbondingAdaptorSigs [][]byte,
-
-) (*pv.RelayerTxResponse, error) {
+) *btcstypes.MsgAddCovenantSigs {
 	msg := &btcstypes.MsgAddCovenantSigs{
 		Signer:                  bc.getTxSigner(),
 		Pk:                      covPubKey,
@@ -859,7 +858,19 @@ func (bc *BabylonController) SubmitCovenantSig(
 		SlashingUnbondingTxSigs: slashUnbondingAdaptorSigs,
 	}
 
-	return bc.reliablySendMsgs([]sdk.Msg{msg})
+	return msg
+}
+
+func (bc *BabylonController) SubmitMultipleCovenantMessages(
+	covenantMsgs []*btcstypes.MsgAddCovenantSigs,
+) (*pv.RelayerTxResponse, error) {
+	var msgs []sdk.Msg
+
+	for _, covenantMsg := range covenantMsgs {
+		msgs = append(msgs, covenantMsg)
+	}
+
+	return bc.reliablySendMsgs(msgs)
 }
 
 func (bc *BabylonController) QueryPendingBTCDelegations() ([]*btcstypes.BTCDelegationResponse, error) {

--- a/staker/stakerapp.go
+++ b/staker/stakerapp.go
@@ -1039,10 +1039,18 @@ func (app *StakerApp) sendUnbondingTxToBtcWithWitness(
 		return fmt.Errorf("failed to receive stakerUnbondingSig.Signature")
 	}
 
-	covenantSigantures := createWitnessSignaturesForPubKeys(
+	covenantSigantures, err := createWitnessSignaturesForPubKeys(
 		params.CovenantPks,
+		params.CovenantQuruomThreshold,
 		unbondingData.CovenantSignatures,
 	)
+
+	if err != nil {
+		app.logger.WithFields(logrus.Fields{
+			"stakingTxHash": stakingTxHash,
+			"err":           err,
+		}).Fatalf("failed to create witness to send unbonding tx")
+	}
 
 	witness, err := unbondingSpendInfo.CreateUnbondingPathWitness(
 		covenantSigantures,


### PR DESCRIPTION
Babylon introduced possiblity of receiving covenant signatures even after quorum is reached -  https://github.com/babylonlabs-io/babylon/pull/130

This pr fixes btc-staker to use only quorum of signatures when building unbonding tx witness.