### PR TITLE
backport: run activation check in separate go routine after startup (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Misc Improvements
+
+* [51](https://github.com/babylonlabs-io/btc-staker/pull/51) Use int64
+  for satoshi amount related values.
+
+### Bug fix
+
+* [#57](https://github.com/babylonlabs-io/btc-staker/pull/57) Use separate go
+routine to check for activation after startup
+
 ## v0.7.1
 
 ### Bug fix

--- a/staker/stakerapp.go
+++ b/staker/stakerapp.go
@@ -621,7 +621,7 @@ func (app *StakerApp) checkTransactionsStatus() error {
 		// resume pre-approval flow
 		if alreadyDelegated {
 			app.wg.Add(1)
-			app.activateVerifiedDelegation(
+			go app.activateVerifiedDelegation(
 				tx.StakingTx,
 				tx.StakingOutputIndex,
 				txHashCopy,


### PR DESCRIPTION
* run activation check in separate go routine after startup
