### PR TITLE
fix dump stakerd.conf by permission denied

### DIFF
--- a/cmd/stakercli/admin/admin.go
+++ b/cmd/stakercli/admin/admin.go
@@ -62,7 +62,7 @@ func dumpCfg(c *cli.Context) error {
 	dir, _ := path.Split(configPath)
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, os.ModeDir); err != nil {
+		if err := os.MkdirAll(dir, 0700); err != nil {
 			return cli.NewExitError(
 				fmt.Sprintf("could not create config directory: %s", err.Error()),
 				1,


### PR DESCRIPTION
Fix 

```bash
 ./build/stakercli admin dump-config 
```

Failed by mkdir mode:

```bash
[btc-staker] open /home/fy/.stakerd/stakerd.conf: permission denied
```

it caused by use error mod:

```go
if err := os.MkdirAll(dir, os.ModeDir); err != nil {
```

this will make path mode be:

```bash
d---------  2 fy   fy   4.0K Oct 15 09:33 .stakerd
```

Now we should use `0700`, as dir 's mode.
