### PR TITLE
feature: do not use inputs already on babyon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#65](https://github.com/babylonlabs-io/btc-staker/pull/65) Various fixes to
 pre-approval flow. Do not send signed staking transactions to Babylon.
 
+* [#67](https://github.com/babylonlabs-io/btc-staker/pull/67) Enable concurrent
+sending of multiple pre-approval staking transactions
+
 ## v0.7.2
 
 ### Bug fix

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -544,6 +544,7 @@ func (tm *TestManager) FinalizeUntilEpoch(t *testing.T, epoch uint64) {
 			},
 			2000,
 			tm.MinerAddr,
+			nil,
 		)
 		require.NoError(t, err)
 		_, err = tm.Sa.Wallet().SendRawTransaction(tx1, true)
@@ -557,6 +558,7 @@ func (tm *TestManager) FinalizeUntilEpoch(t *testing.T, epoch uint64) {
 			},
 			2000,
 			tm.MinerAddr,
+			nil,
 		)
 		require.NoError(t, err)
 		_, err = tm.Sa.Wallet().SendRawTransaction(tx2, true)
@@ -804,6 +806,7 @@ func (tm *TestManager) sendWatchedStakingTx(
 		[]*wire.TxOut{stakingInfo.StakingOutput},
 		2000,
 		tm.MinerAddr,
+		nil,
 	)
 	require.NoError(t, err)
 	txHash := tx.TxHash()
@@ -1677,6 +1680,7 @@ func TestBitcoindWalletRpcApi(t *testing.T) {
 		[]*wire.TxOut{newOutput},
 		btcutil.Amount(2000),
 		walletAddress,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -742,7 +742,7 @@ func (tm *TestManager) sendStakingTxBTC(
 	return hashFromString
 }
 
-func (tm *TestManager) sendMultipleStakingTx(t *testing.T, testStakingData []*testStakingData) []*chainhash.Hash {
+func (tm *TestManager) sendMultipleStakingTx(t *testing.T, testStakingData []*testStakingData, sendToBabylonFirst bool) []*chainhash.Hash {
 	var hashes []*chainhash.Hash
 	for _, data := range testStakingData {
 		fpBTCPKs := []string{}
@@ -756,7 +756,7 @@ func (tm *TestManager) sendMultipleStakingTx(t *testing.T, testStakingData []*te
 			data.StakingAmount,
 			fpBTCPKs,
 			int64(data.StakingTime),
-			false,
+			sendToBabylonFirst,
 		)
 		require.NoError(t, err)
 		txHash, err := chainhash.NewHashFromStr(res.TxHash)
@@ -770,14 +770,21 @@ func (tm *TestManager) sendMultipleStakingTx(t *testing.T, testStakingData []*te
 		stakingDetails, err := tm.StakerClient.StakingDetails(context.Background(), hashStr)
 		require.NoError(t, err)
 		require.Equal(t, stakingDetails.StakingTxHash, hashStr)
-		require.Equal(t, stakingDetails.StakingState, proto.TransactionState_SENT_TO_BTC.String())
+
+		if sendToBabylonFirst {
+			require.Equal(t, stakingDetails.StakingState, proto.TransactionState_SENT_TO_BABYLON.String())
+		} else {
+			require.Equal(t, stakingDetails.StakingState, proto.TransactionState_SENT_TO_BTC.String())
+		}
 	}
 
-	mBlock := tm.mineBlock(t)
-	require.Equal(t, len(hashes)+1, len(mBlock.Transactions))
+	if !sendToBabylonFirst {
+		mBlock := tm.mineBlock(t)
+		require.Equal(t, len(hashes)+1, len(mBlock.Transactions))
 
-	_, err := tm.BabylonClient.InsertBtcBlockHeaders([]*wire.BlockHeader{&mBlock.Header})
-	require.NoError(t, err)
+		_, err := tm.BabylonClient.InsertBtcBlockHeaders([]*wire.BlockHeader{&mBlock.Header})
+		require.NoError(t, err)
+	}
 	return hashes
 }
 
@@ -1349,7 +1356,7 @@ func TestMultipleWithdrawableStakingTransactions(t *testing.T) {
 		testStakingData3,
 		testStakingData4,
 		testStakingData5,
-	})
+	}, false)
 
 	go tm.mineNEmptyBlocks(t, params.ConfirmationTimeBlocks, true)
 
@@ -1381,6 +1388,61 @@ func TestMultipleWithdrawableStakingTransactions(t *testing.T) {
 	require.Equal(t, withdrawableTransactionsResp.Transactions[2].StakingTxHash, txHashes[3].String())
 
 	require.Equal(t, withdrawableTransactionsResp.Transactions[2].TransactionIdx, "4")
+}
+
+func TestMultiplePreApprovalTransactions(t *testing.T) {
+	t.Parallel()
+	// need to have at least 300 block on testnet as only then segwit is activated.
+	// Mature output is out which has 100 confirmations, which means 200mature outputs
+	// will generate 300 blocks
+	numMatureOutputs := uint32(200)
+	ctx, cancel := context.WithCancel(context.Background())
+	tm := StartManager(t, ctx, numMatureOutputs)
+	defer tm.Stop(t, cancel)
+	tm.insertAllMinedBlocksToBabylon(t)
+
+	cl := tm.Sa.BabylonController()
+	params, err := cl.Params()
+	require.NoError(t, err)
+	minStakingTime := params.MinStakingTime
+	stakingTime1 := minStakingTime
+	stakingTime2 := minStakingTime + 4
+	stakingTime3 := minStakingTime + 1
+
+	testStakingData1 := tm.getTestStakingData(t, tm.WalletPubKey, stakingTime1, 10000, 1)
+	testStakingData2 := testStakingData1.withStakingTime(stakingTime2)
+	testStakingData3 := testStakingData1.withStakingTime(stakingTime3)
+
+	tm.createAndRegisterFinalityProviders(t, testStakingData1)
+	txHashes := tm.sendMultipleStakingTx(t, []*testStakingData{
+		testStakingData1,
+		testStakingData2,
+		testStakingData3,
+	}, true)
+
+	for _, txHash := range txHashes {
+		txHash := txHash
+		tm.waitForStakingTxState(t, txHash, proto.TransactionState_SENT_TO_BABYLON)
+	}
+
+	pend, err := tm.BabylonClient.QueryPendingBTCDelegations()
+	require.NoError(t, err)
+	require.Len(t, pend, 3)
+	tm.insertCovenantSigForDelegation(t, pend[0])
+	tm.insertCovenantSigForDelegation(t, pend[1])
+	tm.insertCovenantSigForDelegation(t, pend[2])
+
+	for _, txHash := range txHashes {
+		txHash := txHash
+		tm.waitForStakingTxState(t, txHash, proto.TransactionState_VERIFIED)
+	}
+
+	// Ultimately we will get 3 tx in the mempool meaning all staking transactions
+	// use valid inputs
+	require.Eventually(t, func() bool {
+		txFromMempool := retrieveTransactionFromMempool(t, tm.TestRpcClient, txHashes)
+		return len(txFromMempool) == 3
+	}, eventuallyWaitTimeOut, eventuallyPollTime)
 }
 
 func TestSendingWatchedStakingTransaction(t *testing.T) {
@@ -1459,7 +1521,7 @@ func TestRestartingTxNotOnBabylon(t *testing.T) {
 	txHashes := tm.sendMultipleStakingTx(t, []*testStakingData{
 		testStakingData1,
 		testStakingData2,
-	})
+	}, false)
 
 	// Confirm tx on btc
 	minedBlocks := tm.mineNEmptyBlocks(t, params.ConfirmationTimeBlocks, false)

--- a/staker/stakerapp.go
+++ b/staker/stakerapp.go
@@ -1382,7 +1382,7 @@ func (app *StakerApp) handleStakingCmd(cmd *stakingRequestCmd) (*chainhash.Hash,
 		[]*wire.TxOut{cmd.stakingOutput},
 		btcutil.Amount(cmd.feeRate),
 		cmd.stakerAddress,
-		app.filteUtxoFnGen(),
+		app.filterUtxoFnGen(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build staking transaction: %w", err)
@@ -1729,7 +1729,7 @@ func (app *StakerApp) WatchStaking(
 	}
 }
 
-func (app *StakerApp) filteUtxoFnGen() walletcontroller.UseUtxoFn {
+func (app *StakerApp) filterUtxoFnGen() walletcontroller.UseUtxoFn {
 	return func(utxo walletcontroller.Utxo) bool {
 		outpoint := utxo.OutPoint
 
@@ -1845,23 +1845,9 @@ func (app *StakerApp) StakeFunds(
 
 	feeRate := app.feeEstimator.EstimateFeePerKb()
 
-	// Create unsigned transaction by wallet without signing. Signing will happen
-	// in next steps
-	tx, err := app.wc.CreateTransaction(
-		[]*wire.TxOut{stakingInfo.StakingOutput},
-		btcutil.Amount(feeRate),
-		stakerAddress,
-		app.filteUtxoFnGen(),
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
 	app.logger.WithFields(logrus.Fields{
 		"stakerAddress": stakerAddress,
 		"stakingAmount": stakingInfo.StakingOutput,
-		"btxTxHash":     tx.TxHash(),
 		"fee":           feeRate,
 	}).Info("Created and signed staking transaction")
 

--- a/stakerdb/trackedtranactionstore.go
+++ b/stakerdb/trackedtranactionstore.go
@@ -640,26 +640,13 @@ func outpointBytes(op *wire.OutPoint) ([]byte, error) {
 		return nil, err
 	}
 
-	binary.Write(&buf, binary.BigEndian, op.Index)
+	err = binary.Write(&buf, binary.BigEndian, op.Index)
 
-	return buf.Bytes(), nil
-}
-
-func outpointFromBytes(b []byte) (*wire.OutPoint, error) {
-	if len(b) != 36 {
-		return nil, fmt.Errorf("invalid outpoint bytes length")
-	}
-
-	hash, err := chainhash.NewHash(b[:32])
 	if err != nil {
 		return nil, err
 	}
 
-	return &wire.OutPoint{
-		Hash:  *hash,
-		Index: binary.BigEndian.Uint32(b[32:]),
-	}, nil
-
+	return buf.Bytes(), nil
 }
 
 func getInputData(tx *wire.MsgTx) (*inputData, error) {

--- a/walletcontroller/interface.go
+++ b/walletcontroller/interface.go
@@ -37,21 +37,31 @@ type TaprootSigningResult struct {
 	FullInputWitness wire.TxWitness
 }
 
+// Function to filer utxos that should be used in transaction creation
+type UseUtxoFn func(utxo Utxo) bool
+
 type WalletController interface {
 	UnlockWallet(timeoutSecs int64) error
 	AddressPublicKey(address btcutil.Address) (*btcec.PublicKey, error)
 	ImportPrivKey(privKeyWIF *btcutil.WIF) error
 	NetworkName() string
+	// passning nil usedUtxoFilter will use all possible spendable utxos to choose
+	// inputs
 	CreateTransaction(
 		outputs []*wire.TxOut,
 		feeRatePerKb btcutil.Amount,
-		changeScript btcutil.Address) (*wire.MsgTx, error)
+		changeScript btcutil.Address,
+		usedUtxoFilter UseUtxoFn,
+	) (*wire.MsgTx, error)
 	SignRawTransaction(tx *wire.MsgTx) (*wire.MsgTx, bool, error)
 	// requires wallet to be unlocked
+	// passning nil usedUtxoFilter will use all possible spendable utxos to choose
+	// inputs
 	CreateAndSignTx(
 		outputs []*wire.TxOut,
 		feeRatePerKb btcutil.Amount,
 		changeAddress btcutil.Address,
+		usedUtxoFilter UseUtxoFn,
 	) (*wire.MsgTx, error)
 	SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)
 	ListOutputs(onlySpendable bool) ([]Utxo, error)


### PR DESCRIPTION
- Do not use inputs which are already on babylon in new staking transactions when using pre-approval flow. This enables concurrent sending of pre-approvals