### PR TITLE
chore: Validate pop cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
 - [#111](https://github.com/babylonlabs-io/btc-staker/pull/111) Add CLI command
 to create phase-1/phase-2 PoP payload
 - [#115](https://github.com/babylonlabs-io/btc-staker/pull/115) Add CLI command
 to create payload for phase-1/phase-2 PoP deletion
 - [#116](https://github.com/babylonlabs-io/btc-staker/pull/116) Add CLI command
 to sign Cosmos ADR-36 messages
+- [#118](https://github.com/babylonlabs-io/btc-staker/pull/118) Add CLI command
+to validate PoP JSON file
 
 ## v0.14.0
 

--- a/cmd/stakercli/pop/pop.go
+++ b/cmd/stakercli/pop/pop.go
@@ -2,8 +2,17 @@ package pop
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
+
+	"github.com/babylonlabs-io/babylon/crypto/bip322"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/urfave/cli"
 
 	"github.com/babylonlabs-io/btc-staker/babylonclient/keyringcontroller"
 	"github.com/babylonlabs-io/btc-staker/cmd/stakercli/helpers"
@@ -11,9 +20,6 @@ import (
 	"github.com/babylonlabs-io/btc-staker/types"
 	ut "github.com/babylonlabs-io/btc-staker/utils"
 	"github.com/babylonlabs-io/btc-staker/walletcontroller"
-	"github.com/btcsuite/btcd/btcutil"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/urfave/cli"
 )
 
 const (
@@ -34,12 +40,13 @@ const (
 var PopCommands = []cli.Command{
 	{
 		Name:     "pop",
-		Usage:    "Commands realted to generation and verification of the Proof of Possession",
+		Usage:    "Commands about proof-of-possession generation and verification",
 		Category: "PoP commands",
 		Subcommands: []cli.Command{
 			generateCreatePopCmd,
 			generateDeletePopCmd,
 			signCosmosAdr36Cmd,
+			validatePopCmd,
 		},
 	},
 }
@@ -67,7 +74,7 @@ var generateCreatePopCmd = cli.Command{
 		cli.StringFlag{
 			Name:  btcNetworkFlag,
 			Usage: "Bitcoin network on which staking should take place (testnet3, mainnet, regtest, simnet, signet)",
-			Value: "testnet3",
+			Value: "main",
 		},
 		cli.StringFlag{
 			Name:  btcWalletHostFlag,
@@ -164,6 +171,151 @@ func generatePop(c *cli.Context) error {
 	}
 
 	helpers.PrintRespJSON(popResponse)
+
+	return nil
+}
+
+var validatePopCmd = cli.Command{
+	Name:      "validate",
+	ShortName: "vp",
+	Usage:     "stakercli pop validate <path-to-pop.json>",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  btcNetworkFlag,
+			Usage: "Bitcoin network (testnet3, mainnet, regtest, simnet, signet)",
+			Value: "main",
+		},
+		cli.StringFlag{
+			Name:  babyAddressPrefixFlag,
+			Usage: "Baby address prefix",
+			Value: "bbn",
+		},
+	},
+	Action:    validatePop,
+	ArgsUsage: "<path-to-pop.json>",
+}
+
+type ValidationResult struct {
+	IsValid       bool   `json:"isValid"`
+	BTCSignValid  bool   `json:"btcSignValid"`
+	BabySignValid bool   `json:"babySignValid"`
+	ErrorMessage  string `json:"errorMessage,omitempty"`
+}
+
+func validatePop(c *cli.Context) error {
+	if c.NArg() != 1 {
+		return fmt.Errorf("expected 1 argument (pop file path), got %d", c.NArg())
+	}
+
+	// Read and parse the PoP file
+	popFilePath := c.Args().First()
+	popFileBytes, err := os.ReadFile(popFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read pop file: %w", err)
+	}
+
+	var popResponse staker.Response
+	if err := json.Unmarshal(popFileBytes, &popResponse); err != nil {
+		return fmt.Errorf("failed to parse pop file: %w", err)
+	}
+
+	// Get network params
+	network := c.String(btcNetworkFlag)
+	networkParams, err := ut.GetBtcNetworkParams(network)
+	if err != nil {
+		return err
+	}
+
+	babyAddressPrefix := c.String(babyAddressPrefixFlag)
+
+	err = ValidatePop(popResponse, networkParams, babyAddressPrefix)
+	if err != nil {
+		return fmt.Errorf("pop validation failed: %w", err)
+	}
+
+	fmt.Println("pop validation succeeded!")
+
+	return nil
+}
+
+func ValidatePop(popResponse staker.Response, btcNetParams *chaincfg.Params, babyPrefix string) error {
+	err := ValidateBTCSignBaby(popResponse.BTCAddress, popResponse.BabyAddress, popResponse.BTCSignBaby, babyPrefix, btcNetParams)
+	if err != nil {
+		return fmt.Errorf("invalid btcSignBaby: %w", err)
+	}
+
+	err = ValidateBabySignBTC(popResponse.BabyPublicKey, popResponse.BabyAddress, popResponse.BTCAddress, popResponse.BabySignBTC)
+	if err != nil {
+		return fmt.Errorf("invalid babySignBtc: %w", err)
+	}
+
+	return nil
+}
+
+func ValidateBTCSignBaby(btcAddr, babyAddr, btcSignBaby, babyPrefix string, btcNetParams *chaincfg.Params) error {
+	btcAddress, err := btcutil.DecodeAddress(btcAddr, btcNetParams)
+	if err != nil {
+		return fmt.Errorf("failed to decode bitcoin address: %w", err)
+	}
+
+	sdkAddressBytes, err := sdk.GetFromBech32(babyAddr, babyPrefix)
+	if err != nil {
+		return fmt.Errorf("failed to decode baby address: %w", err)
+	}
+
+	sdkAddress := sdk.AccAddress(sdkAddressBytes)
+
+	bech32cosmosAddressString, err := sdk.Bech32ifyAddressBytes(babyPrefix, sdkAddress.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to get babylon address bytes")
+	}
+
+	schnorrSigBase64, err := base64.StdEncoding.DecodeString(btcSignBaby)
+	if err != nil {
+		return fmt.Errorf("failed to decode btcSignBaby: %w", err)
+	}
+
+	witness, err := bip322.SimpleSigToWitness(schnorrSigBase64)
+	if err != nil {
+		return fmt.Errorf("failed to convert btcSignBaby to witness: %w", err)
+	}
+
+	return bip322.Verify(
+		[]byte(bech32cosmosAddressString),
+		witness,
+		btcAddress,
+		btcNetParams,
+	)
+}
+
+func ValidateBabySignBTC(babyPk, babyAddr, btcAddress, babySigOverBTCPk string) error {
+	babyPubKeyBz, err := base64.StdEncoding.DecodeString(babyPk)
+	if err != nil {
+		return err
+	}
+
+	babyPubKey := &secp256k1.PubKey{
+		Key: babyPubKeyBz,
+	}
+
+	babySignBTC := []byte(btcAddress)
+	base64Bytes := base64.StdEncoding.EncodeToString(babySignBTC)
+	babySignBtcDoc := staker.NewCosmosSignDoc(babyAddr, base64Bytes)
+	babySignBtcMarshaled, err := json.Marshal(babySignBtcDoc)
+	if err != nil {
+		return err
+	}
+
+	babySignBtcBz := sdk.MustSortJSON(babySignBtcMarshaled)
+
+	secp256SigBase64, err := base64.StdEncoding.DecodeString(babySigOverBTCPk)
+	if err != nil {
+		return err
+	}
+
+	if !babyPubKey.VerifySignature(babySignBtcBz, secp256SigBase64) {
+		return fmt.Errorf("invalid babySignBtc")
+	}
 
 	return nil
 }

--- a/cmd/stakercli/pop/pop_test.go
+++ b/cmd/stakercli/pop/pop_test.go
@@ -1,0 +1,31 @@
+package pop_test
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+
+	"github.com/babylonlabs-io/btc-staker/cmd/stakercli/pop"
+	"github.com/babylonlabs-io/btc-staker/staker"
+)
+
+var popsToVerify = []staker.Response{
+	{
+		BabyAddress:   "bbn1xjz8fs9vkmefdqaxan5kv2d09vmwzru7jhy424",
+		BTCAddress:    "bc1qcpty6lpueassw9rhfrvkq6h0ufnhmc2nhgvpcr",
+		BTCPublicKey:  "79f71003589158b2579345540b08bbc74974c49dd5e0782e31d0de674540d513",
+		BTCSignBaby:   "AkcwRAIgcrI2IdD2JSFVIeQmtRA3wFjjiy+qEvqbX57rn6xvWWECIDis7vHSJeR8X91uMQReG0pPQFFLpeM0ga4BW+Tt2V54ASEDefcQA1iRWLJXk0VUCwi7x0l0xJ3V4HguMdDeZ0VA1RM=",
+		BabySignBTC:   "FnYTm9ZbhJZY202R9YBkjGEJqeJ/n5McZBpGH38P2pt0YRcjwOh8XgoeVQTU9So7/RHVHHdKNB09DVmtQJ7xtw==",
+		BabyPublicKey: "Asezdqkvh+kLbuD75DirSwi/QFbJjFe2SquiivMaPS65",
+	},
+}
+
+func TestPoPValidate(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range popsToVerify {
+		err := pop.ValidatePop(p, &chaincfg.MainNetParams, "bbn")
+		require.NoError(t, err)
+	}
+}

--- a/cmd/stakercli/pop/pop_test.go
+++ b/cmd/stakercli/pop/pop_test.go
@@ -2,7 +2,6 @@ package pop_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func TestValidatePoPCmd(t *testing.T) {
 	// Test ValidatePopCmd with the JSON file
 	app := testutil.TestApp()
 	validatePop := []string{
-		"stakercli", "pop", "validate", fmt.Sprintf("%s", tmpFile),
+		"stakercli", "pop", "validate", tmpFile,
 	}
 	err = app.Run(validatePop)
 	require.NoError(t, err)

--- a/itest/testutil/appcli.go
+++ b/itest/testutil/appcli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/babylonlabs-io/babylon/testutil/datagen"
 	cmdadmin "github.com/babylonlabs-io/btc-staker/cmd/stakercli/admin"
 	cmddaemon "github.com/babylonlabs-io/btc-staker/cmd/stakercli/daemon"
+	"github.com/babylonlabs-io/btc-staker/cmd/stakercli/pop"
 	"github.com/babylonlabs-io/btc-staker/cmd/stakercli/transaction"
 	"github.com/babylonlabs-io/networks/parameters/parser"
 	"github.com/stretchr/testify/require"
@@ -56,6 +57,7 @@ func TestApp() *cli.App {
 	app.Commands = append(app.Commands, cmddaemon.DaemonCommands...)
 	app.Commands = append(app.Commands, cmdadmin.AdminCommands...)
 	app.Commands = append(app.Commands, transaction.TransactionCommands...)
+	app.Commands = append(app.Commands, pop.PopCommands...)
 	return app
 }
 


### PR DESCRIPTION
This PR:
- let `generate-create-pop` output the result to a JSON file
- added `validate` pop cmd which takes the pop JSON file and verify pop