### PR TITLE
fix: fix comments to base branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+- [#114](https://github.com/babylonlabs-io/btc-staker/pull/114) **Multi-staking support**.
+This PR contains a series of PRs on multi-staking support and BTC staking integration.
+
 ## v0.15.1
 
 ### Bug fixes

--- a/itest/containers/config.go
+++ b/itest/containers/config.go
@@ -28,8 +28,6 @@ func NewImageConfig(t *testing.T) ImageConfig {
 	babylondVersion, err := testutil.GetBabylonVersion()
 	require.NoError(t, err)
 
-	babylondVersion = "latest" // TODO: change back
-
 	return ImageConfig{
 		BitcoindRepository: dockerBitcoindRepository,
 		BitcoindVersion:    dockerBitcoindVersionTag,


### PR DESCRIPTION
This PR fixes comments to https://github.com/babylonlabs-io/btc-staker/pull/114 and adds changelog for it