### PR TITLE
chore: set default keyring backend to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+- [#142](https://github.com/babylonlabs-io/btc-staker/pull/142) Set config default
+keyring backend to "file" type
 - [#138](https://github.com/babylonlabs-io/btc-staker/pull/138) Adds prometheus metrics
 configuration to enabled it (disabled by default).
 * [#114](https://github.com/babylonlabs-io/btc-staker/pull/114) **Multi-staking support**.

--- a/itest/manager.go
+++ b/itest/manager.go
@@ -48,6 +48,7 @@ import (
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
@@ -367,6 +368,7 @@ func StartManagerStakerApp(
 	// need to use this one to send otherwise we will have account sequence mismatch
 	// errors
 	cfg.BabylonConfig.Key = "test-spending-key"
+	cfg.BabylonConfig.KeyringBackend = keyring.BackendTest
 
 	// Big adjustment to make sure we have enough gas in our transactions
 	cfg.BabylonConfig.GasAdjustment = 3.0

--- a/stakercfg/babylon.go
+++ b/stakercfg/babylon.go
@@ -4,7 +4,10 @@ import (
 	"time"
 
 	bbncfg "github.com/babylonlabs-io/babylon/client/config"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 )
+
+const DefaultKeyringBackend = keyring.BackendFile
 
 type BBNConfig struct {
 	Key            string        `long:"key" description:"name of the BTC staker key name inside the keyring to sign transactions with"`
@@ -32,7 +35,7 @@ func DefaultBBNConfig() BBNConfig {
 		RPCAddr:        dc.RPCAddr,
 		GRPCAddr:       dc.GRPCAddr,
 		AccountPrefix:  dc.AccountPrefix,
-		KeyringBackend: dc.KeyringBackend,
+		KeyringBackend: DefaultKeyringBackend,
 		GasAdjustment:  dc.GasAdjustment,
 		GasPrices:      dc.GasPrices,
 		KeyDirectory:   DefaultStakerdDir,


### PR DESCRIPTION
- modified `stakercli admin dump-config` to generate the Babylon keyring backend as file