### PR TITLE
chore: spend stake check confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ This PR contains a series of PRs on multi-staking support and BTC staking integr
 * [#134](https://github.com/babylonlabs-io/btc-staker/pull/134) Removal of both the watch-staking
 endpoint and the post-approval flow, and reduction of state in the database.
 
+### Bug fixes
+
+* [#172](https://github.com/babylonlabs-io/btc-staker/pull/172) chore: spend stake check confirmation
+
 ## v0.15.7
 
 ### Improvements

--- a/staker/stakerapp.go
+++ b/staker/stakerapp.go
@@ -1620,12 +1620,16 @@ func (app *App) SpendStake(stakingTxHash *chainhash.Hash) (*chainhash.Hash, *btc
 	// on the Babylon chain, we can now be certain that it has been confirmed in Bitcoin.
 	// Therefore, we only need to check whether the unbonding transaction has been confirmed.
 	unbondingTxHash := udi.UnbondingTransaction.TxHash()
-	confirmation, _, err := app.Wallet().TxDetails(
+	confirmation, txStatus, err := app.Wallet().TxDetails(
 		&unbondingTxHash,
 		udi.UnbondingTransaction.TxOut[0].PkScript,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot spend staking output. Error getting confirmation info from btc: %w", err)
+	}
+
+	if confirmation == nil {
+		return nil, nil, fmt.Errorf("cannot spend staking output. Tx status: %s", txStatus.String())
 	}
 
 	var spendStakeTxInfo *spendStakeTxInfo

--- a/walletcontroller/interface.go
+++ b/walletcontroller/interface.go
@@ -1,6 +1,7 @@
 package walletcontroller
 
 import (
+	"fmt"
 	staking "github.com/babylonlabs-io/babylon/btcstaking"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -22,6 +23,19 @@ const (
 	TxInMemPool
 	TxInChain
 )
+
+func (ts TxStatus) String() string {
+	switch ts {
+	case TxNotFound:
+		return "TxNotFound"
+	case TxInMemPool:
+		return "TxInMemPool"
+	case TxInChain:
+		return "TxInChain"
+	default:
+		return fmt.Sprintf("UnknownTxStatus(%d)", int(ts))
+	}
+}
 
 type SpendPathDescription struct {
 	ControlBlock *txscript.ControlBlock


### PR DESCRIPTION
Handles nil deref that happens if tx is in mempool, response and err returned are `nil` which we didn't handle

<img width="796" alt="image" src="https://github.com/user-attachments/assets/48523414-1d97-45e7-b731-baffbdbc5ef5" />
