### PR TITLE
bump docker publish wf

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@cfbd5e4db5e575edf77a160fe533918c4f3a4498  # v0.13.2
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@d71e8faea3b6612f80ee621ec2984096b0ab9c9e # v0.14.2
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) }}
     with:
       go-version: '1.23'
@@ -37,7 +37,7 @@ jobs:
             needs.lint_test.result == 'success'
           )}}
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@5151754256060bf160c411d0784f831f29882106  # v0.13.4
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@d71e8faea3b6612f80ee621ec2984096b0ab9c9e # v0.14.2
     secrets: inherit
     permissions:
       # required for all workflows


### PR DESCRIPTION
we need to bump this in order to merge this PR:

```

 
--
Failed to run: Error: invalid version string 'v1.60.2', golangci-lint v1 is not supported by golangci-lint-action >= v7., Error: invalid version string 'v1.60.2', golangci-lint v1 is not supported by golangci-lint-action >= v7.     at parseVersion (/home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:93319:15)     at getRequestedVersion (/home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:93368:36)     at getVersion (/home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:93401:24)     at install (/home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:92623:56)     at prepareEnv (/home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:92938:49)     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
 

<br class="Apple-interchange-newline">
````