### PR TITLE
chore: update ci and publish workflow versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,16 @@ on:
     branches:
     - '**'
 
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@92817762adb32ebbe832abfebe98efa09f7072e2 #v0.13.5
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.1
     with:
       go-version: '1.24.1'
       go-lint-version: 'v2.7.2'
@@ -19,7 +23,8 @@ jobs:
       run-lint: true
 
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@92817762adb32ebbe832abfebe98efa09f7072e2 #v0.13.5
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.1
     secrets: inherit
     with:
       publish: false
+      trivy_nofail: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@847cd8a6ff9c64e401ce922d12532979d9ac5e93 # v0.14.5
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.1
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs['skip-lint-test'] == true) }}
     with:
       go-version: '1.23'
@@ -37,7 +37,7 @@ jobs:
             needs.lint_test.result == 'success'
           )}}
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@847cd8a6ff9c64e401ce922d12532979d9ac5e93 # v0.14.5
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@0adff9d36a387ebfc921621f2e6b357230f8c08e # v0.18.1
     secrets: inherit
     permissions:
       # required for all workflows
@@ -46,3 +46,4 @@ jobs:
       packages: read
     with:
       publish: true
+      trivy_nofail: true


### PR DESCRIPTION
## Summary

- Add concurrency group to `ci` workflow
- Update reusable workflows in `ci` workflow (to match https://github.com/babylonlabs-io/babylon/pull/1986)
- Update reusable workflows in `publish` workflow (to match https://github.com/babylonlabs-io/babylon/pull/1986)
